### PR TITLE
Add reactions.*.{json,md} by aki017/slack-api-docs-generator

### DIFF
--- a/methods/reactions.add.json
+++ b/methods/reactions.add.json
@@ -1,0 +1,49 @@
+{
+  "desc": "This method adds a reaction (emoji) to an item (file, file comment, channel message, group message, or direct message).\nOne of file, file_comment, or the combination of channel and timestamp must be specified.",
+  "args": {
+    "token": {
+      "required": true,
+      "example": "xxxx-xxxxxxxxx-xxxx",
+      "desc": "Authentication token (Requires scope: post)"
+    },
+    "name": {
+      "required": true,
+      "example": "thumbsup",
+      "desc": "Reaction (emoji) name."
+    },
+    "file": {
+      "required": false,
+      "example": "F1234567890",
+      "desc": "File to add reaction to."
+    },
+    "file_comment": {
+      "required": false,
+      "example": "Fc1234567890",
+      "desc": "File comment to add reaction to."
+    },
+    "channel": {
+      "required": false,
+      "example": "C1234567890",
+      "desc": "Channel where the message to add reaction to was posted."
+    },
+    "timestamp": {
+      "required": false,
+      "example": "1234567890.123456",
+      "desc": "Timestamp of the message to add reaction to."
+    }
+  },
+  "errors": {
+    "bad_timestamp": "Value passed for `timestamp` was invalid.",
+    "file_not_found": "File specified by `file` does not exist.",
+    "file_comment_not_found": "File comment specified by `file_comment` does not exist.",
+    "message_not_found": "Message specified by `channel` and `timestamp` does not exist.",
+    "no_item_specified": "`file`, `file_comment`, or combination of `channel` and `timestamp` was not specified.",
+    "invalid_name": "Value passed for `name` was invalid.",
+    "already_reacted": "The specified item already has the user/reaction combination.",
+    "too_many_emoji": "The limit for distinct reactions (i.e emoji) on the item has been reached.",
+    "too_many_reactions": "The limit for reactions a person may add to the item has been reached.",
+    "not_authed": "No authentication token provided.",
+    "invalid_auth": "Invalid authentication token.",
+    "account_inactive": "Authentication token is for a deleted user or team."
+  }
+}

--- a/methods/reactions.add.md
+++ b/methods/reactions.add.md
@@ -1,0 +1,44 @@
+This method adds a reaction (emoji) to an item (file, file comment, channel message, group message, or direct message). One of `file`, `file_comment`, or the combination of `channel` and `timestamp` must be specified.
+
+## Arguments
+
+This method has the URL `https://slack.com/api/reactions.add` and follows the [Slack Web API calling conventions](/web#basics).
+
+| Argument | Example | Required | Description |
+| --- | --- | --- | --- |
+| `token` | `xxxx-xxxxxxxxx-xxxx` | Required | Authentication token (Requires scope: `post`) |
+| `name` | `thumbsup` | Required | Reaction (emoji) name. |
+| `file` | `F1234567890` | Optional | File to add reaction to. |
+| `file_comment` | `Fc1234567890` | Optional | File comment to add reaction to. |
+| `channel` | `C1234567890` | Optional | Channel where the message to add reaction to was posted. |
+| `timestamp` | `1234567890.123456` | Optional | Timestamp of the message to add reaction to. |
+
+## Response
+
+```
+{
+    "ok": true
+}
+```
+
+After making this call, the reaction is saved and [a `reaction_added` event](/events/reaction_added) is broadcast through the [RTM API](/rtm) for the calling user.
+
+## Errors
+
+This table lists the expected errors that this method will return. However, other errors can be returned in the case where the service is down or other unexpected factors affect processing. Callers should _always_ check the value of the `ok` params in the response.
+
+| Error | Description |
+| --- | --- |
+| `bad_timestamp` | Value passed for `timestamp` was invalid. |
+| `file_not_found` | File specified by `file` does not exist. |
+| `file_comment_not_found` | File comment specified by `file_comment` does not exist. |
+| `message_not_found` | Message specified by `channel` and `timestamp` does not exist. |
+| `no_item_specified` | `file`, `file_comment`, or combination of `channel` and `timestamp` was not specified. |
+| `invalid_name` | Value passed for `name` was invalid. |
+| `already_reacted` | The specified item already has the user/reaction combination. |
+| `too_many_emoji` | The limit for distinct reactions (i.e emoji) on the item has been reached. |
+| `too_many_reactions` | The limit for reactions a person may add to the item has been reached. |
+| `not_authed` | No authentication token provided. |
+| `invalid_auth` | Invalid authentication token. |
+| `account_inactive` | Authentication token is for a deleted user or team. |
+

--- a/methods/reactions.get.json
+++ b/methods/reactions.get.json
@@ -1,0 +1,45 @@
+{
+  "desc": "This method returns a list of all reactions for a single item (file, file comment, channel message, group message, or direct message).",
+  "args": {
+    "token": {
+      "required": true,
+      "example": "xxxx-xxxxxxxxx-xxxx",
+      "desc": "Authentication token (Requires scope: read)"
+    },
+    "file": {
+      "required": false,
+      "example": "F1234567890",
+      "desc": "File to get reactions for."
+    },
+    "file_comment": {
+      "required": false,
+      "example": "Fc1234567890",
+      "desc": "File comment to get reactions for."
+    },
+    "channel": {
+      "required": false,
+      "example": "C1234567890",
+      "desc": "Channel where the message to get reactions for was posted."
+    },
+    "timestamp": {
+      "required": false,
+      "example": "1234567890.123456",
+      "desc": "Timestamp of the message to get reactions for."
+    },
+    "full": {
+      "required": false,
+      "example": " ",
+      "desc": "If true always return the complete reaction list."
+    }
+  },
+  "errors": {
+    "bad_timestamp": "Value passed for `timestamp` was invalid.",
+    "file_not_found": "File specified by `file` does not exist.",
+    "file_comment_not_found": "File comment specified by `file_comment` does not exist.",
+    "message_not_found": "Message specified by `channel` and `timestamp` does not exist.",
+    "no_item_specified": "`file`, `file_comment`, or combination of `channel` and `timestamp` was not specified.",
+    "not_authed": "No authentication token provided.",
+    "invalid_auth": "Invalid authentication token.",
+    "account_inactive": "Authentication token is for a deleted user or team."
+  }
+}

--- a/methods/reactions.get.md
+++ b/methods/reactions.get.md
@@ -1,0 +1,64 @@
+This method returns a list of all reactions for a single item (file, file comment, channel message, group message, or direct message).
+
+## Arguments
+
+This method has the URL `https://slack.com/api/reactions.get` and follows the [Slack Web API calling conventions](/web#basics).
+
+| Argument | Example | Required | Description |
+| --- | --- | --- | --- |
+| `token` | `xxxx-xxxxxxxxx-xxxx` | Required | Authentication token (Requires scope: `read`) |
+| `file` | `F1234567890` | Optional | File to get reactions for. |
+| `file_comment` | `Fc1234567890` | Optional | File comment to get reactions for. |
+| `channel` | `C1234567890` | Optional | Channel where the message to get reactions for was posted. |
+| `timestamp` | `1234567890.123456` | Optional | Timestamp of the message to get reactions for. |
+| `full` | &nbsp; | Optional | If true always return the complete reaction list. |
+
+## Response
+
+The response contains the item with reactions.
+
+```
+{
+    "type": "message",
+    "channel": "C2147483705",
+    "message": {
+        ...
+        "reactions": [
+            {
+                "name": "astonished",
+                "count": 3,
+                "users": ["U1", "U2", "U3"]
+            },
+            {
+                "name": "clock1"
+                "count": 2,
+                "users": ["U1", "U2", "U3"]
+            }
+        ]
+    },
+},
+```
+
+Different item types can be reacted to. The item returned has a `type` property, the other properties depend on the type of item. The possible types are:
+
+- **`message`** : the item will have a `message` property containing a [message object](/docs/messages) and a `channel` property containing the channel ID for the message.
+- **`file`** : this item will have a `file` property containing a [file object](/types/file).
+- **`file_comment`** : the item will have a `file` property containing the [file object](/types/file) and a `comment` property containing the file comment.
+
+The users array in the `reactions` property might not always contain all users that have reacted (we limit it to X users, and X might change), however `count` will always represent the count of all users who made that reaction (i.e. it may be greater than `users.length`). If the authenticated user has a given reaction then they are guaranteed to appear in the `users` array, regardless of whether `count` is greater than `users.length` or not. If the complete list of users is required they can still be obtained by specifying the `full` argument.
+
+## Errors
+
+This table lists the expected errors that this method will return. However, other errors can be returned in the case where the service is down or other unexpected factors affect processing. Callers should _always_ check the value of the `ok` params in the response.
+
+| Error | Description |
+| --- | --- |
+| `bad_timestamp` | Value passed for `timestamp` was invalid. |
+| `file_not_found` | File specified by `file` does not exist. |
+| `file_comment_not_found` | File comment specified by `file_comment` does not exist. |
+| `message_not_found` | Message specified by `channel` and `timestamp` does not exist. |
+| `no_item_specified` | `file`, `file_comment`, or combination of `channel` and `timestamp` was not specified. |
+| `not_authed` | No authentication token provided. |
+| `invalid_auth` | Invalid authentication token. |
+| `account_inactive` | Authentication token is for a deleted user or team. |
+

--- a/methods/reactions.list.json
+++ b/methods/reactions.list.json
@@ -1,0 +1,36 @@
+{
+  "desc": "This method returns a list of all items (file, file comment, channel message, group message, or direct message) reacted to by a user.",
+  "args": {
+    "token": {
+      "required": true,
+      "example": "xxxx-xxxxxxxxx-xxxx",
+      "desc": "Authentication token (Requires scope: read)"
+    },
+    "user": {
+      "required": false,
+      "example": "U1234567890",
+      "desc": "Show reactions made by this user. Defaults to the authed user."
+    },
+    "full": {
+      "required": false,
+      "example": " ",
+      "desc": "If true always return the complete reaction list."
+    },
+    "count": {
+      "required": false,
+      "example": "100",
+      "desc": "Number of items to return per page."
+    },
+    "page": {
+      "required": false,
+      "example": "2",
+      "desc": "Page number of results to return."
+    }
+  },
+  "errors": {
+    "user_not_found": "Value passed for `user` was invalid.",
+    "not_authed": "No authentication token provided.",
+    "invalid_auth": "Invalid authentication token.",
+    "account_inactive": "Authentication token is for a deleted user or team."
+  }
+}

--- a/methods/reactions.list.md
+++ b/methods/reactions.list.md
@@ -1,0 +1,95 @@
+This method returns a list of all items (file, file comment, channel message, group message, or direct message) reacted to by a user.
+
+## Arguments
+
+This method has the URL `https://slack.com/api/reactions.list` and follows the [Slack Web API calling conventions](/web#basics).
+
+| Argument | Example | Required | Description |
+| --- | --- | --- | --- |
+| `token` | `xxxx-xxxxxxxxx-xxxx` | Required | Authentication token (Requires scope: `read`) |
+| `user` | `U1234567890` | Optional | Show reactions made by this user. Defaults to the authed user. |
+| `full` | &nbsp; | Optional | If true always return the complete reaction list. |
+| `count` | `100` | Optional, default=100 | Number of items to return per page. |
+| `page` | `2` | Optional, default=1 | Page number of results to return. |
+
+## Response
+
+The response contains a list of items with reactions followed by pagination information.
+
+```
+{
+    "ok": true,
+    "items": [
+        {
+            "type": "message",
+            "channel": "C2147483705",
+            "message": {
+                ...
+                "reactions": [
+                    {
+                        "name": "astonished",
+                        "count": 3,
+                        "users": ["U1", "U2", "U3"]
+                    },
+                    {
+                        "name": "clock1"
+                        "count": 2,
+                        "users": ["U1", "U2", "U3"]
+                    }
+                ]
+            },
+        },
+        {
+            "type": "file",
+            "file": { ... },
+            "reactions": [
+                {
+                    "name": "thumbsup",
+                    "count": 1,
+                    "users": ["U1"]
+                }
+            ]
+        }
+        {
+            "type": "file_comment",
+            "file": { ... },
+            "comment": { ... },
+            "reactions": [
+                {
+                    "name": "facepalm",
+                    "count": 1034,
+                    "users": ["U1", "U2", "U3", "U4", "U5"]
+                }
+            ]
+        }
+    ],
+    "paging": {
+        "count": 100,
+        "total": 4,
+        "page": 1,
+        "pages": 1
+    }
+}
+```
+
+Different item types can be reacted to. Every item in the list has a `type` property, the other properties depend on the type of item. The possible types are:
+
+- **`message`** : the item will have a `message` property containing a [message object](/docs/messages) and a `channel` property containing the channel ID for the message.
+- **`file`** : this item will have a `file` property containing a [file object](/types/file).
+- **`file_comment`** : the item will have a `file` property containing the [file object](/types/file) and a `comment` property containing the file comment.
+
+The users array in the `reactions` property might not always contain all users that have reacted (we limit it to X users, and X might change), however `count` will always represent the count of all users who made that reaction (i.e. it may be greater than `users.length`). If the authenticated user has a given reaction then they are guaranteed to appear in the `users` array, regardless of whether `count` is greater than `users.length` or not. If the complete list of users is required they can still be obtained by specifying the `full` argument.
+
+The paging information contains the `count` of items returned, the `total`number of items reacted to, the `page` of results returned in this response and the total number of `pages` available. Please note that the max `count` value is `1000` and the max `page` value is `100`.
+
+## Errors
+
+This table lists the expected errors that this method will return. However, other errors can be returned in the case where the service is down or other unexpected factors affect processing. Callers should _always_ check the value of the `ok` params in the response.
+
+| Error | Description |
+| --- | --- |
+| `user_not_found` | Value passed for `user` was invalid. |
+| `not_authed` | No authentication token provided. |
+| `invalid_auth` | Invalid authentication token. |
+| `account_inactive` | Authentication token is for a deleted user or team. |
+

--- a/methods/reactions.remove.json
+++ b/methods/reactions.remove.json
@@ -1,0 +1,47 @@
+{
+  "desc": "This method removes a reaction (emoji) from an item (file, file comment, channel message, group message, or direct message).\nOne of file, file_comment, or the combination of channel and timestamp must be specified.",
+  "args": {
+    "token": {
+      "required": true,
+      "example": "xxxx-xxxxxxxxx-xxxx",
+      "desc": "Authentication token (Requires scope: post)"
+    },
+    "name": {
+      "required": true,
+      "example": "thumbsup",
+      "desc": "Reaction (emoji) name."
+    },
+    "file": {
+      "required": false,
+      "example": "F1234567890",
+      "desc": "File to remove reaction from."
+    },
+    "file_comment": {
+      "required": false,
+      "example": "Fc1234567890",
+      "desc": "File comment to remove reaction from."
+    },
+    "channel": {
+      "required": false,
+      "example": "C1234567890",
+      "desc": "Channel where the message to remove reaction from was posted."
+    },
+    "timestamp": {
+      "required": false,
+      "example": "1234567890.123456",
+      "desc": "Timestamp of the message to remove reaction from."
+    }
+  },
+  "errors": {
+    "bad_timestamp": "Value passed for `timestamp` was invalid.",
+    "file_not_found": "File specified by `file` does not exist.",
+    "file_comment_not_found": "File comment specified by `file_comment` does not exist.",
+    "message_not_found": "Message specified by `channel` and `timestamp` does not exist.",
+    "no_item_specified": "`file`, `file_comment`, or combination of `channel` and `timestamp` was not specified.",
+    "invalid_name": "Value passed for `name` was invalid.",
+    "no_reaction": "The specified item does not have the user/reaction combination.",
+    "not_authed": "No authentication token provided.",
+    "invalid_auth": "Invalid authentication token.",
+    "account_inactive": "Authentication token is for a deleted user or team."
+  }
+}

--- a/methods/reactions.remove.md
+++ b/methods/reactions.remove.md
@@ -1,0 +1,42 @@
+This method removes a reaction (emoji) from an item (file, file comment, channel message, group message, or direct message). One of `file`, `file_comment`, or the combination of `channel` and `timestamp` must be specified.
+
+## Arguments
+
+This method has the URL `https://slack.com/api/reactions.remove` and follows the [Slack Web API calling conventions](/web#basics).
+
+| Argument | Example | Required | Description |
+| --- | --- | --- | --- |
+| `token` | `xxxx-xxxxxxxxx-xxxx` | Required | Authentication token (Requires scope: `post`) |
+| `name` | `thumbsup` | Required | Reaction (emoji) name. |
+| `file` | `F1234567890` | Optional | File to remove reaction from. |
+| `file_comment` | `Fc1234567890` | Optional | File comment to remove reaction from. |
+| `channel` | `C1234567890` | Optional | Channel where the message to remove reaction from was posted. |
+| `timestamp` | `1234567890.123456` | Optional | Timestamp of the message to remove reaction from. |
+
+## Response
+
+```
+{
+    "ok": true
+}
+```
+
+After making this call, the reaction is removed and [a `reaction_removed` event](/events/reaction_removed) is broadcast through the [RTM API](/rtm) for the calling user.
+
+## Errors
+
+This table lists the expected errors that this method will return. However, other errors can be returned in the case where the service is down or other unexpected factors affect processing. Callers should _always_ check the value of the `ok` params in the response.
+
+| Error | Description |
+| --- | --- |
+| `bad_timestamp` | Value passed for `timestamp` was invalid. |
+| `file_not_found` | File specified by `file` does not exist. |
+| `file_comment_not_found` | File comment specified by `file_comment` does not exist. |
+| `message_not_found` | Message specified by `channel` and `timestamp` does not exist. |
+| `no_item_specified` | `file`, `file_comment`, or combination of `channel` and `timestamp` was not specified. |
+| `invalid_name` | Value passed for `name` was invalid. |
+| `no_reaction` | The specified item does not have the user/reaction combination. |
+| `not_authed` | No authentication token provided. |
+| `invalid_auth` | Invalid authentication token. |
+| `account_inactive` | Authentication token is for a deleted user or team. |
+


### PR DESCRIPTION
## What is this?

This PR is the addition of `reactions` doc. Official Slack document has `reactions`, but `slack-api-doc` has no `reactions`, So I create this.
- [reactions.add method | Slack](https://api.slack.com/methods/reactions.add)
- [reactions.get method | Slack](https://api.slack.com/methods/reactions.get)
- [reactions.list method | Slack](https://api.slack.com/methods/reactions.list)
- [reactions.remove method | Slack](https://api.slack.com/methods/reactions.remove)

The diffs is generated by `aki017/slack-api-docs-generator`. But fix the  [issue](https://github.com/aki017/slack-api-docs-generator/issues/1) of markdown.

Please tell me if the generation is wrong.
